### PR TITLE
oh thanks allauth for the broken templatetag

### DIFF
--- a/eggplant_project/templates/base.html
+++ b/eggplant_project/templates/base.html
@@ -41,7 +41,7 @@
                         <li class="dropdown">
                             
                                 <a data-toggle="dropdown" class="dropdown-toggle" 
-                                href="#" aria-expanded="true">{% if user.is_authenticated %}{% user_display user %}{%else%}Welcome!{%endif%}<strong></strong> <span class="caret"></span></a>
+                                href="#" aria-expanded="true">{% if user.is_authenticated %}{{ user.get_full_name|default:user.username }}{%else%}Welcome!{%endif%}<strong></strong> <span class="caret"></span></a>
                             
                             <ul class="dropdown-menu">
                                  <li><a href="{% url 'eggplant:dashboard:home' %}">Home</a></li>


### PR DESCRIPTION
Does not correctly default to displaying the username even though thats what the allauth docs say.

Look at this empty arrow:

![noname](https://cloud.githubusercontent.com/assets/374612/9289236/25da586e-4369-11e5-9aba-4ea82618d080.png)
