### PR TITLE
use django suit

### DIFF
--- a/eggplant_project/settings/base.py
+++ b/eggplant_project/settings/base.py
@@ -52,7 +52,7 @@ AUTHENTICATION_BACKENDS = (
 # Application definition
 
 INSTALLED_APPS = (
-    'django_admin_bootstrapped',  # django-admin-bootstrapped
+    'suit',  # django-admin-bootstrapped
 
     'django.contrib.admin',
     'django.contrib.auth',

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 Django==1.8.3
 
 django-allauth==0.19.1
-django-admin-bootstrapped==2.5.0
+django-suit==0.2.14
 django-bootstrap3==5.4.0
 django-recaptcha==1.0.4
 django-getpaid==1.7.2


### PR DESCRIPTION
I've been using this a lot and really like it. It doesn't require any changes and doesnt break with the template logic from django.contrib.admin.

Here's how it looks:

![screenshot from 2015-09-20 01 30 23](https://cloud.githubusercontent.com/assets/374612/9978567/38160412-5f37-11e5-9a2a-8dbdc3f7ab2d.png)

...it's free for non-commercial use.

https://github.com/darklow/django-suit
