### PR TITLE
Fixing up the user reset feature - 2. attempt

### DIFF
--- a/eggplant_project/authnadapter.py
+++ b/eggplant_project/authnadapter.py
@@ -34,18 +34,3 @@ class EggplantAccountAdapter(DefaultAccountAdapter):
             accepted=True
         ).count()
         return bool(ret)
-
-    def clean_email(self, email):
-        """
-        Validates an email value. Dynamically restricts what email addresses
-        can be chosen.
-        """
-        email = forms.fields.EmailField().clean(value=email)
-        is_taken = (
-            EmailAddress.objects.filter(email__iexact=email).exists() or
-            User.objects.filter(email__iexact=email).exists()
-        )
-        if is_taken:
-            raise forms.ValidationError(_("This email is already taken. "
-                                          "Please choose another."))
-        return email

--- a/eggplant_project/templates/account/email/base.html
+++ b/eggplant_project/templates/account/email/base.html
@@ -1,0 +1,4 @@
+{% block content %}{% endblock %}
+<hr>
+
+<h3>FoodNet - Mad fra alle til alle!</h3>

--- a/eggplant_project/templates/account/password_reset.html
+++ b/eggplant_project/templates/account/password_reset.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {% load account %}
-{% load sekizai_tags %}
 
 {% block head_title %}Log ud{% endblock %}
 

--- a/eggplant_project/templates/account/password_reset_done.html
+++ b/eggplant_project/templates/account/password_reset_done.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {% load account %}
-{% load sekizai_tags %}
 
 {% block head_title %}Mail sendt{% endblock %}
 

--- a/eggplant_project/templates/account/password_reset_from_key.html
+++ b/eggplant_project/templates/account/password_reset_from_key.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {% load account %}
-{% load sekizai_tags %}
 
 {% block head_title %}Ændr kodeord{% endblock %}
 

--- a/eggplant_project/templates/account/password_reset_from_key_done.html
+++ b/eggplant_project/templates/account/password_reset_from_key_done.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {% load account %}
-{% load sekizai_tags %}
 
 {% block head_title %}Kodeord skiftet{% endblock %}
 

--- a/eggplant_project/templates/account/signup.html
+++ b/eggplant_project/templates/account/signup.html
@@ -1,7 +1,6 @@
 {% extends "base.html" %}
 
 {% load account %}
-{% load sekizai_tags %}
 
 {% block head_title %}Opret bruger{% endblock %}
 


### PR DESCRIPTION
The allauth user password reset was broken,
- unused sekizai_tags was attempted loaded (but this was not in requirements/base.txt)
- a clean_email method in the authnadapter.py was rejecting the users email when submitted (because it was in use .... as would be expected).
- the sending of the password reset link was broken because no templates/account/email/base.html existed.
