### PR TITLE
Removed: django-extensions

### DIFF
--- a/eggplant_project/settings/dev.py
+++ b/eggplant_project/settings/dev.py
@@ -42,7 +42,7 @@ ADMINS = ()
 os.environ['RECAPTCHA_TESTING'] = 'True'
 
 INSTALLED_APPS += ('debug_toolbar',)
-INSTALLED_APPS += ('django_extensions',)
+#INSTALLED_APPS += ('django_extensions',)
 
 MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 

--- a/eggplant_project/settings/dev.py
+++ b/eggplant_project/settings/dev.py
@@ -42,7 +42,6 @@ ADMINS = ()
 os.environ['RECAPTCHA_TESTING'] = 'True'
 
 INSTALLED_APPS += ('debug_toolbar',)
-#INSTALLED_APPS += ('django_extensions',)
 
 MIDDLEWARE_CLASSES += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
 

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -1,5 +1,4 @@
 -r test.txt
 django-debug-toolbar>=1.3.0
-django-extensions>=1.5.2
 ipdb>=0.8
 whitenoise==2.0.2


### PR DESCRIPTION
It doesn't seem we need it and it breaks a fresh install as it uses south migrations.
