### PR TITLE
Changed null to blank on the UserProfile's fields.

### DIFF
--- a/eggplant/profiles/migrations/0003_auto_20151225_1844.py
+++ b/eggplant/profiles/migrations/0003_auto_20151225_1844.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('profiles', '0002_userprofile_photo'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='userprofile',
+            name='photo',
+            field=models.ImageField(null=True, upload_to='', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='userprofile',
+            name='sex',
+            field=models.CharField(choices=[('', '-----'), ('female', 'female'), ('male', 'male'), ('other', 'other')], default='', max_length=100, blank=True),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='userprofile',
+            name='tel2',
+            field=models.CharField(default='', max_length=15, blank=True),
+            preserve_default=False,
+        ),
+    ]

--- a/eggplant/profiles/models.py
+++ b/eggplant/profiles/models.py
@@ -39,13 +39,13 @@ class UserProfile(models.Model):
     postcode = models.CharField(max_length=30)
     city = models.CharField(max_length=50)
     tel = models.CharField(max_length=15)
-    tel2 = models.CharField(max_length=15, null=True)
+    tel2 = models.CharField(max_length=15, blank=True)
     sex = models.CharField(
         max_length=100,
         choices=SEX_CHOICES,
-        null=True,
+        blank=True
     )
-    photo = models.ImageField()
+    photo = models.ImageField(blank=True, null=True)
 
     created = models.DateTimeField(auto_now_add=True, editable=False)
     changed = models.DateTimeField(auto_now=True, editable=False)


### PR DESCRIPTION
Reading the Django ["Model field reference"](https://docs.djangoproject.com/en/1.8/ref/models/fields/) I found

> "Avoid using null on string-based fields such as CharField and TextField because empty string values will always be stored as empty strings, not as NULL."

and

> "For both string-based and non-string-based fields, you will also need to set blank=True if you wish to permit empty values in forms, as the null parameter only affects database storage (see blank)."

At the same time the UserProfile model had a couple of CharFields with null=True and I suspect that what was actually intended was that these fields should be optional ... thats the reasoning behind this PR.

Git blame tells me @valberg added the models, maybe you want to comment or merge this in? :)
