### PR TITLE
Implementing a single click logout, skipping the allauth confirmation page

### DIFF
--- a/eggplant_project/urls.py
+++ b/eggplant_project/urls.py
@@ -25,6 +25,12 @@ urlpatterns = [
         eggplant.profiles.views.NewUserPassword.as_view(),
         name='account_set_password'),
 
+    # override django-allauth logout so no confirmation is needed
+    # see: http://www.sarahhagstrom.com/2013/09/the-missing-django-allauth-tutorial/#Remove_the_logout-confirmation_step
+    url(r'^account/logout/$',
+        'django.contrib.auth.views.logout',
+        {'next_page': '/'}),
+
     url(r'^getpaid/', include('getpaid.urls')),
 
     url(r'^account/', include('allauth.urls')),


### PR DESCRIPTION
I think the logout confirmation page is unnecessary and bad practice from a UX perspective - how about you @andreaslloyd? This PR logs the user out as they click the logout button from the menu, without asking them to confirm.
