### PR TITLE
Rearranged the page header again

### DIFF
--- a/eggplant/core/static/css/eggplant.css
+++ b/eggplant/core/static/css/eggplant.css
@@ -21,6 +21,35 @@ body {
     margin: 0;
 }
 
+/* Everything _header.html related */
+.page-header {
+    margin-top: -20px;
+    padding: 20px;
+    background: white;
+    border: 0;
+    margin-bottom: 50px;
+}
+
+.page-header .logo {
+    height: 120px;
+    width: 120px;
+    margin: auto;
+    background-size: contain;
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
+    background-color: #EDEDED;
+    border-radius: 60px;
+    display: block;
+}
+
+/* sm */
+@media (max-width: 991px) and (min-width: 768px) {
+    .page-header .logo {
+        height: 90px;
+        width: 90px;
+    }
+}
+
 /* Setting up font sizes */
 
 .form-control, .btn {

--- a/eggplant/urls.py
+++ b/eggplant/urls.py
@@ -2,14 +2,15 @@ from django.conf.urls import include, url
 
 urlpatterns = [
     url(r'^invitations/',
-        include('eggplant.invitations.urls', namespace='invitations')
-    ),
+        include('eggplant.invitations.urls', namespace='invitations')),
     url(r'^profiles/',
         include('eggplant.profiles.urls', namespace='profiles')),
     url(r'^departments/',
-        include('eggplant.departments.urls', namespace='departments',)
-    ),
-    url(r'^accounts/', include('eggplant.accounts.urls', namespace='accounts')),
-    url(r'^market/', include('eggplant.market.urls', namespace='market')),
-    url(r'^', include('eggplant.dashboard.urls', namespace='dashboard')),
+        include('eggplant.departments.urls', namespace='departments',)),
+    url(r'^accounts/',
+        include('eggplant.accounts.urls', namespace='accounts')),
+    url(r'^market/',
+        include('eggplant.market.urls', namespace='market')),
+    url(r'^',
+        include('eggplant.dashboard.urls', namespace='dashboard')),
 ]

--- a/eggplant/urls.py
+++ b/eggplant/urls.py
@@ -1,14 +1,12 @@
 from django.conf.urls import include, url
 
 urlpatterns = [
-    url(
-        r'^invitations/',
+    url(r'^invitations/',
         include('eggplant.invitations.urls', namespace='invitations')
     ),
     url(r'^profiles/',
         include('eggplant.profiles.urls', namespace='profiles')),
-    url(
-        r'^departments/',
+    url(r'^departments/',
         include('eggplant.departments.urls', namespace='departments',)
     ),
     url(r'^accounts/', include('eggplant.accounts.urls', namespace='accounts')),

--- a/eggplant_project/static/css/account/login.css
+++ b/eggplant_project/static/css/account/login.css
@@ -1,34 +1,6 @@
-.logo {
-    height: 120px;
-    width: 120px;
-    margin: auto;
-    background-size: contain;
-    background-position: 50% 50%;
-    background-repeat: no-repeat;
-    background-color: #EDEDED;
-    border-radius: 60px;
-}
-
-/* sm */
-@media (max-width: 991px) and (min-width: 768px) {
-    .logo {
-        height: 90px;
-        width: 90px;
-    }
-}
-
 .eggplants-bg {
     background-image: url('../../img/eggplants-bg.jpg');
     background-size: cover;
-    padding-top: 0;
-}
-
-.page-header {
-    padding: 20px;
-    background: white;
-    border: 0;
-    margin-top: 0;
-    margin-bottom: 60px;
 }
 
 .panel-opaque {

--- a/eggplant_project/templates/_header.html
+++ b/eggplant_project/templates/_header.html
@@ -1,0 +1,21 @@
+{% load staticfiles %}
+<div class="page-header">
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-2 col-xs-12 vcenter">
+                <a class="logo"
+                    style="background-image:url('{% static COOP_LOGO %}')"
+                     href="{% url 'eggplant:dashboard:home' %}">
+                </a>
+            </div><!--
+            This comment eliminates whitespace, see:
+            http://stackoverflow.com/questions/20547819/vertical-align-with-bootstrap-3
+            --><div class="col-sm-10 col-xs-12 vcenter">
+                <h1 class="visible-md-block visible-lg-block">{{COOP_NAME}}</h1>
+                <h2 class="visible-sm-block">{{COOP_NAME}}</h2>
+                <h3 class="visible-xs-block">{{COOP_NAME}}</h3>
+                <p>{{COOP_DESCRIPTION}}</p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/eggplant_project/templates/account/login.html
+++ b/eggplant_project/templates/account/login.html
@@ -2,8 +2,8 @@
 
 {% load i18n %}
 {% load account %}
-{% load bootstrap3 %}
 {% load staticfiles %}
+{% load bootstrap3 %}
 
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 
@@ -15,26 +15,6 @@
 {% block content_classes %}{% endblock %}
 
 {% block content %}
-<div class="page-header">
-    <div class="container">
-        <div class="row">
-            <div class="col-sm-2 col-xs-12 vcenter">
-                <div class="logo"
-                    style="background-image:url('{% static COOP_LOGO %}')">
-                </div>
-            </div><!--
-            This comment eliminates whitespace, see:
-            http://stackoverflow.com/questions/20547819/vertical-align-with-bootstrap-3
-            --><div class="col-sm-10 col-xs-12 vcenter">
-                <h1 class="visible-md-block visible-lg-block">{{COOP_NAME}}</h1>
-                <h2 class="visible-sm-block">{{COOP_NAME}}</h2>
-                <h3 class="visible-xs-block">{{COOP_NAME}}</h3>
-                <p>{{COOP_DESCRIPTION}}</p>
-            </div>
-        </div>
-    </div>
-</div>
-
 <div class="container">
     <div class="row">
         <div class="col-md-6">

--- a/eggplant_project/templates/base.html
+++ b/eggplant_project/templates/base.html
@@ -20,11 +20,14 @@
     {% block app_css %}{% endblock %}
 </head>
 <body class="{% block body_classes %}{% endblock %}">
-    <div class="container">
+    
     {% if user.is_authenticated %}
-        {% include '_navbar.html' %}
+        <div class="container">
+            {% include '_navbar.html' %}
+        </div>
+    {% else%}
+        {% include '_header.html' %}
     {% endif %}
-    </div>
 
     <!-- Content -->
     <section class="{% block content_classes %}container{% endblock %}">


### PR DESCRIPTION
Now the page header (large logo + coop name and description) is only shown when the user is not authenticated.
