### PR TITLE
allow users to remove disabled or out of stock items from their cart

### DIFF
--- a/eggplant/market/forms.py
+++ b/eggplant/market/forms.py
@@ -7,8 +7,7 @@ from eggplant.core.widgets import MoneyWidget
 
 
 class BasketItemForm(forms.Form):
-    product = forms.ModelChoiceField(Product.objects.filter(stock__gt=0,
-                                                            enabled=True))
+    product = forms.ModelChoiceField(Product.objects.all())
     quantity = forms.fields.IntegerField(min_value=0, max_value=100,
                                          required=True)
     delivery_date = forms.fields.DateField(required=False)

--- a/eggplant/market/views/cart.py
+++ b/eggplant/market/views/cart.py
@@ -39,6 +39,10 @@ class AddToCart(BaseCartActionView):
                         "than %d items in your basket.") % (max_items)
                 messages.warning(self.request, msg)
                 return redirect('eggplant:market:market_home')
+            if form.cleaned_data['product'].stock < 1 or not form.cleaned_data['product'].enabled:
+                msg = _("Sorry, this product is currently out of stock")
+                messages.warning(self.request, msg)
+                return redirect('eggplant:market:market_home')
             self.basket.add_to_items(**form.cleaned_data)
             stock = form.cleaned_data['product'].stock - \
                 form.cleaned_data['quantity']


### PR DESCRIPTION
I noticed a little bug when using the demo. The admin currently has a product that is out of stock in their cart, and if you attempt to delete it from the cart you get an error because the form thinks any action involving out of stock or disabled items is invalid (when in reality, it should only be for adding items to the cart).

I made a small patch that will allow users to remove disabled or out of stock items from the cart, but still keeping it impossible to add them. 
